### PR TITLE
Validation for words returns the wrong boolean value

### DIFF
--- a/Class/Core/Validation.php
+++ b/Class/Core/Validation.php
@@ -315,7 +315,7 @@ class Validation
 	 */
 	protected function word_rule($data)
 	{
-		return preg_match("/\W/", $data);
+		return ! preg_match("/\W/", $data);
 	}
 
 


### PR DESCRIPTION
`\Core\Validation::word_rule()` returns false when it should return true, and vice versa.
