### PR TITLE
Use the correct namespace for CLI tools

### DIFF
--- a/CLI
+++ b/CLI
@@ -35,7 +35,7 @@ try
 }
 catch (Exception $e)
 {
-	\Core\Error::exception($e);
+	\Micro\Error::exception($e);
 }
 
 // End


### PR DESCRIPTION
It looks like ack didn't look through the CLI file when I was looking for uses of the \Core namespace last time. I guess this is what happens when I outsource some of my thinking to the computer...
