### PR TITLE
Fix Syntax: MySQL ORDER BY

### DIFF
--- a/Class/Micro/Database.php
+++ b/Class/Micro/Database.php
@@ -325,7 +325,7 @@ class Database
 		$sql = ' ORDER BY ';
 
 		// Add each order clause
-		foreach($fields as $k => $v) $sql .= "$i$v$i, ";
+		foreach($fields as $v) $sql .= "$i$v$i, ";
 
 		// Remove ending ", "
 		return substr($sql, 0, -2);


### PR DESCRIPTION
\Model\Club::select('fetch', '*', false, false, false, false, array('id')); - makes error
without fix: SELECT \* FROM `club` ORDER BY `0` id (Syntax error)
with fix: SELECT \* FROM `club` ORDER BY `id`
