### PR TITLE
Fix: If I want to select column

### DIFF
--- a/Class/Micro/ORM.php
+++ b/Class/Micro/ORM.php
@@ -438,7 +438,7 @@ class ORM
 	 */
 	public static function count(array $where = NULL)
 	{
-		return self::select('column', NULL, NULL, $where);
+		return self::select('column', 'COUNT(*)', NULL, $where);
 	}
 
 

--- a/Class/Micro/ORM.php
+++ b/Class/Micro/ORM.php
@@ -397,20 +397,20 @@ class ORM
 	 * @param array $order by conditions
 	 * @return mixed
 	 */
-	public static function select($func, $column, $model = NULL, $where = NULL, $limit = 0, $offset = 0, $order = NULL)
+	public static function select($func, $column = 'COUNT(*)', $model = NULL, $where = NULL, $limit = 0, $offset = 0, $order = NULL)
 	{
 		$model = $model ?: get_called_class();
 		$order = ($order ?: array()) + (static::$order_by ?: array());
 
 		// Count queries don't have offsets, limits, or order conditions
-		if(!$column)
+		if($column == 'COUNT(*)')
 		{
 			$limit = $offset = 0;
 			$order = array();
 		}
 
 		// Generate select statement SQL
-		list($sql, $params) = static::$db->select(($column ? $column : 'COUNT(*)'), $model::$table, $where, $limit, $offset, $order);
+		list($sql, $params) = static::$db->select($column, $model::$table, $where, $limit, $offset, $order);
 
 		return static::$db->$func($sql, $params, ($column == '*' OR strpos($column, ',')) ? NULL : 0);
 	}

--- a/Class/Micro/ORM.php
+++ b/Class/Micro/ORM.php
@@ -403,7 +403,7 @@ class ORM
 		$order = ($order ?: array()) + (static::$order_by ?: array());
 
 		// Count queries don't have offsets, limits, or order conditions
-		if($func != 'fetch')
+		if(!$column)
 		{
 			$limit = $offset = 0;
 			$order = array();
@@ -412,7 +412,7 @@ class ORM
 		// Generate select statement SQL
 		list($sql, $params) = static::$db->select(($column ? $column : 'COUNT(*)'), $model::$table, $where, $limit, $offset, $order);
 
-		return static::$db->$func($sql, $params, ($column == '*' OR strpos($column, ',')) ? NULL : 0);
+		return static::$db->$func($sql, $params, ($column == '*' OR strpos($columns, ',')) ? NULL : 0);
 	}
 
 

--- a/Class/Micro/ORM.php
+++ b/Class/Micro/ORM.php
@@ -412,7 +412,7 @@ class ORM
 		// Generate select statement SQL
 		list($sql, $params) = static::$db->select(($column ? $column : 'COUNT(*)'), $model::$table, $where, $limit, $offset, $order);
 
-		return static::$db->$func($sql, $params, ($column == '*' OR strpos($columns, ',')) ? NULL : 0);
+		return static::$db->$func($sql, $params, ($column == '*' OR strpos($column, ',')) ? NULL : 0);
 	}
 
 


### PR DESCRIPTION
If I write:
\Model\Club::select('column', 'id', false, false, 1, 2, array('id'=>'DESC'); 
 Limit, Offset and Order will work incorrect.

If I want to get club with offset 3 - I can not get it.  
 \Model\Club::select('row', 'id', false, false, 1, 3, array('id'=>'DESC');

This fix corrects it.
