### PR TITLE
Fix: Give identificator

### DIFF
--- a/Class/Micro/ORM.php
+++ b/Class/Micro/ORM.php
@@ -503,7 +503,7 @@ class ORM
 	 * Insert the current object into the database table
 	 *
 	 * @param array $data to insert
-	 * @return mixed
+	 * @return int
 	 */
 	protected function insert(array $data)
 	{


### PR DESCRIPTION
If I want to give to __construct array with ID (so as not to tripped autoincrement)
Example: $user = new User(array('user_name' => 'me1', 'password' => '777'));
'user_name' - is primary key and identificator
Without fix: $user->save() - will not work

If I want to change id on row:
$user = new User(1); $user->load();
$user->user_name = 2;
$user->save(); - will not work

With fix: will be work.
